### PR TITLE
Fix building and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 *.class
 *.idea
 target
-*.idea
 *.iml
 packaged.yaml
 dist
+.bloop
+.metals
+.vscode
+metals.sbt
+/.bsp/sbt.json

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 
 name := "graalvm-scala-lambda"
-scalaVersion := "2.12.8"
-assemblyJarName in assembly := "graalvm-scala-lambda.jar"
-mainClass in assembly := Some("bootstrap")
+scalaVersion := "2.13.8"
+assembly / assemblyJarName := "graalvm-scala-lambda.jar"
+assembly / mainClass := Some("bootstrap")
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %% "requests" % "0.1.8",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "0.47.0" % Compile, 
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.47.0" % Provided // required only in compile-time
+  "com.lihaoyi" %% "requests" % "0.7.1",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.13.38" % Compile,
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.13.38" % Provided // required only in compile-time
 )
 
 scalacOptions ++= Seq(

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
-# Compiles to Java classes, builds a jar, and then compiles to a native Linux executable 
+# Compiles to Java classes, builds a jar, and then compiles to a native Linux executable
 
 set -e
 
 mkdir -p dist
 sbt clean assembly
 docker build -f linuxbuild.dockerfile -t linuxbuild .
-docker run -v "$(pwd -P)/target/scala-2.12":/tmp/target -v "$(pwd -P)/dist":/tmp/dist linuxbuild
-
+docker run -v "$(pwd -P)/target/scala-2.13":/tmp/target -v "$(pwd -P)/dist":/tmp/dist linuxbuild

--- a/linuxbuild.dockerfile
+++ b/linuxbuild.dockerfile
@@ -1,5 +1,10 @@
-FROM oracle/graalvm-ce:1.0.0-rc16
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java17-22.1.0
 
 WORKDIR /tmp/dist
-CMD native-image -jar /tmp/target/graalvm-scala-lambda.jar --enable-url-protocols=http bootstrap
-
+RUN gu install native-image
+CMD native-image \
+  -jar /tmp/target/graalvm-scala-lambda.jar \
+  -H:ReflectionConfigurationFiles=/tmp/target/classes/META-INF/native-image/reflect-config.json \
+  --enable-url-protocols=http \
+  -J-Xmx2G -J-Xms2G \
+  bootstrap

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.7.1

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "java.lang.invoke.VarHandle",
+    "methods": [
+      {
+        "name": "releaseFence",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/main/scala/AWSLambdaTypes.scala
+++ b/src/main/scala/AWSLambdaTypes.scala
@@ -44,7 +44,7 @@ case class RequestEvent(
 )
 
 object RequestEvent {
-  private implicit val codec: JsonValueCodec[RequestEvent] = JsonCodecMaker.make[RequestEvent](CodecMakerConfig())
+  private implicit val codec: JsonValueCodec[RequestEvent] = JsonCodecMaker.make
 
   def fromJsonSafe(s: String): Option[RequestEvent] = Try(readFromString[RequestEvent](s)) match {
     case util.Success(re) => Some(re)
@@ -59,10 +59,7 @@ case class LambdaResponse(
   body: String,
   isBase64Encoded: Boolean = false
 ) {
-  private implicit val codec: JsonValueCodec[LambdaResponse] = JsonCodecMaker.make[LambdaResponse](CodecMakerConfig())
+  private implicit val codec: JsonValueCodec[LambdaResponse] = JsonCodecMaker.make
 
   def toJson: String = writeToString(this)
 }
-
-
-

--- a/src/main/scala/bootstrap.scala
+++ b/src/main/scala/bootstrap.scala
@@ -12,7 +12,7 @@ object bootstrap {
     while (true) {
       val r = requests.get(nextEventUrl)
       val statusCode = for {
-        requestEvent <- RequestEvent.fromJsonSafe(r.text)
+        requestEvent <- RequestEvent.fromJsonSafe(r.text())
         deadlineMs <- getRequiredHeader(r, "lambda-runtime-deadline-ms").map(_.toLong)
         requestId <- getRequiredHeader(r, "lambda-runtime-aws-request-id")
         statusCode = handleRequest(runtimeApiHost, requestEvent, requestId, deadlineMs)


### PR DESCRIPTION
Hey @swartzrock, it's been a while, and a project has stopped building. I've updated all dependencies.
All works very well now! 

### Details of the solution

It's about issues with `ERROR [internal] load metadata for docker.io/oracle/graalvm-ce:1.0.0-rc16` like this one:
```console
failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

I fixed this and updated all other dependencies to refresh the project to the current stack (while still using Scala 2, just all the latest, including the newest tooling). 

I could use GraalVM 22.2.0, but I didn't because of warnings like the following:
```console
WARNING: Unknown module: org.graalvm.nativeimage.llvm specified to --add-exports
```
It might be connected with a regression discussed in several places: https://github.com/oracle/graal/issues/4671 https://github.com/oracle/graal/issues/4782

Although of this issue, **22.2.0 also works very well with this project**. However, the goal was to deliver a fully clean change without a single warning.

That's why I used the previous stable version. The GraalVM 22.1.0 works perfectly.

### The outcome

All builds beautiful, as below:
```console
❯ ./build.sh
[info] welcome to sbt 1.7.1 (Eclipse Adoptium Java 17)
[info] loading global plugins from /Users/baldram/.sbt/1.0/plugins
[info] loading settings for project graalvm-scala-lambda-build from assembly.sbt ...
[info] loading project definition from /Users/baldram/git/community/graalvm-scala-lambda/project
[info] loading settings for project graalvm-scala-lambda from build.sbt ...
[info] set current project to graalvm-scala-lambda (in build file:/Users/baldram/git/community/graalvm-scala-lambda/)
[success] Total time: 0 s, completed 17 Aug 2022, 14:11:02
[info] compiling 2 Scala sources to /Users/baldram/git/community/graalvm-scala-lambda/target/scala-2.13/classes ...
[info] Strategy 'discard' was applied to a file (Run the task at debug level to see details)
[info] Strategy 'rename' was applied to 2 files (Run the task at debug level to see details)
[success] Total time: 6 s, completed 17 Aug 2022, 14:11:09
[+] Building 0.8s (7/7) FINISHED
 => [internal] load build definition from linuxbuild.dockerfile                                                                                            0.0s
 => => transferring dockerfile: 48B                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                            0.0s
 => [internal] load metadata for ghcr.io/graalvm/graalvm-ce:ol8-java17-22.1.0                                                                              0.7s
 => [1/3] FROM ghcr.io/graalvm/graalvm-ce:ol8-java17-22.1.0@sha256:7a9562a544249739ecdf24f10eb88636f71240f57faa1d13fabb61ce9c60f3d7                        0.0s
 => CACHED [2/3] WORKDIR /tmp/dist                                                                                                                         0.0s
 => CACHED [3/3] RUN gu install native-image                                                                                                               0.0s
 => exporting to image                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                    0.0s
 => => writing image sha256:a4e4fef47adbd6b802a82b26ec663260338f07c0b53ab4291b6ae7f9cb54112f                                                               0.0s
 => => naming to docker.io/library/linuxbuild                                                                                                              0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
========================================================================================================================
GraalVM Native Image: Generating 'bootstrap' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                    (3.7s @ 0.17GB)
 Version info: 'GraalVM 22.1.0 Java 17 CE'
 C compiler: gcc (redhat, x86_64, 8.5.0)
 Garbage collector: Serial GC
 1 user-provided feature(s)
  - com.oracle.svm.polyglot.scala.ScalaFeature
[2/7] Performing analysis...  [**********]                                                              (18.4s @ 1.08GB)
   5,091 (82.31%) of  6,185 classes reachable
   6,565 (57.03%) of 11,512 fields reachable
  24,863 (44.44%) of 55,944 methods reachable
     303 classes,   116 fields, and 1,020 methods registered for reflection
      60 classes,    61 fields, and    54 methods registered for JNI access
[3/7] Building universe...                                                                               (1.7s @ 1.01GB)
[4/7] Parsing methods...      [*]                                                                        (1.1s @ 1.14GB)
[5/7] Inlining methods...     [****]                                                                     (1.3s @ 1.27GB)
[6/7] Compiling methods...    [***]                                                                     (11.4s @ 1.35GB)
[7/7] Creating image...                                                                                  (3.2s @ 1.35GB)
   9.43MB (39.37%) for code area:   15,282 compilation units
  12.23MB (51.03%) for image heap:   3,329 classes and 156,712 objects
   2.30MB ( 9.60%) for other data
  23.96MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
 805.29KB java.util                                            1.93MB byte[] for code metadata
 553.53KB com.sun.crypto.provider                              1.59MB byte[] for general heap data
 408.92KB java.lang.invoke                                     1.43MB byte[] for java.lang.String
 389.37KB java.lang                                            1.34MB java.lang.String
 346.96KB com.oracle.svm.core.reflect                          1.20MB java.lang.Class
 343.29KB java.text                                          422.20KB java.util.HashMap$Node
 331.55KB sun.security.x509                                  397.73KB com.oracle.svm.core.hub.DynamicHubCompanion
 328.21KB scala.collection.immutable                         271.97KB java.util.concurrent.ConcurrentHashMap$Node
 293.73KB java.io                                            261.87KB java.lang.String[]
 236.06KB java.util.regex                                    213.83KB byte[] for reflection metadata
      ... 196 additional packages                                 ... 1217 additional object types
                                           (use GraalVM Dashboard to see all)
------------------------------------------------------------------------------------------------------------------------
                        1.4s (3.3% of total time) in 53 GCs | Peak RSS: 2.28GB | CPU load: 4.67
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /tmp/dist/bootstrap (executable)
 /tmp/dist/bootstrap.build_artifacts.txt
========================================================================================================================
Finished generating 'bootstrap' in 43.2s.
```

And of course the function deploys and runs very well.
